### PR TITLE
Added Cooks Assistant.

### DIFF
--- a/src/main/java/org/dreambot/Main.java
+++ b/src/main/java/org/dreambot/Main.java
@@ -3,13 +3,15 @@ package org.dreambot;
 import org.dreambot.api.script.AbstractScript;
 import org.dreambot.api.script.Category;
 import org.dreambot.api.script.ScriptManifest;
-import org.dreambot.behaviour.combat.CombatBranch;
-import org.dreambot.behaviour.combat.leaves.CombatLeaf;
-import org.dreambot.behaviour.fallback.FallbackLeaf;
-import org.dreambot.behaviour.timeout.TimeoutLeaf;
 import org.dreambot.framework.Tree;
+import org.dreambot.framework.fallback.FallbackLeaf;
+import org.dreambot.framework.timeout.TimeoutLeaf;
 import org.dreambot.paint.CustomPaint;
 import org.dreambot.paint.PaintInfo;
+import org.dreambot.quests.cooksassistant.CooksAssistant;
+import org.dreambot.quests.cooksassistant.FinishedCooksAssistant;
+import org.dreambot.quests.cooksassistant.GatherItemsLeaf;
+import org.dreambot.quests.cooksassistant.TalkToCookLeaf;
 import org.dreambot.quests.sheepshearer.CollectWoolLeaf;
 import org.dreambot.quests.sheepshearer.SheepShearer;
 import org.dreambot.quests.sheepshearer.SpinWoolLeaf;
@@ -56,7 +58,14 @@ public class Main extends AbstractScript implements PaintInfo {
     // Add all of the branches and leaves to the tree
     private void instantiateTree() {
         tree.addBranches(
-                new SheepShearer().addLeafs(new TalkToFredLeaf(), new CollectWoolLeaf(), new SpinWoolLeaf())
+                new TimeoutLeaf(),
+                // Place your own branches and leaves below this. The TimeoutLeaf waits one tick and decrements Timing.tickTimeout int.
+
+                new CooksAssistant().addLeafs(new GatherItemsLeaf(), new TalkToCookLeaf(), new FinishedCooksAssistant()),
+                //new SheepShearer().addLeafs(new TalkToFredLeaf(), new CollectWoolLeaf(), new SpinWoolLeaf())
+
+                // Place your own branches and leaves above this. The FallbackLeaf is a failsafe in case there none of the leafs execute, and generates new Timing.tickTimeout.
+                new FallbackLeaf()
         );
     }
 

--- a/src/main/java/org/dreambot/framework/fallback/FallbackLeaf.java
+++ b/src/main/java/org/dreambot/framework/fallback/FallbackLeaf.java
@@ -1,0 +1,18 @@
+package org.dreambot.framework.fallback;
+
+import org.dreambot.framework.Leaf;
+import org.dreambot.utilities.Timing;
+
+public class FallbackLeaf extends Leaf {
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public int onLoop() {
+        //By calling Timing.loopReturn() we set a net tickTimeout and wait one tick.
+        return Timing.loopReturn();
+    }
+}

--- a/src/main/java/org/dreambot/framework/timeout/TimeoutLeaf.java
+++ b/src/main/java/org/dreambot/framework/timeout/TimeoutLeaf.java
@@ -1,0 +1,23 @@
+package org.dreambot.framework.timeout;
+
+
+import org.dreambot.api.utilities.Sleep;
+import org.dreambot.framework.Leaf;
+import org.dreambot.utilities.Timing;
+
+public class TimeoutLeaf extends Leaf {
+
+    // If this leaf is called, that means that there is currently a tick timeout
+    @Override
+    public boolean isValid() {
+        return Timing.tickTimeout > 0;
+    }
+
+    @Override
+    public int onLoop() {
+        // Decrement the tick timeout by one and wait for exactly one tick
+        Timing.tickTimeout--;
+        Sleep.sleepTick();
+        return 60;
+    }
+}

--- a/src/main/java/org/dreambot/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/org/dreambot/quests/cooksassistant/CooksAssistant.java
@@ -1,0 +1,10 @@
+package org.dreambot.quests.cooksassistant;
+
+import org.dreambot.framework.Branch;
+import org.dreambot.utilities.Timing;
+
+public class CooksAssistant extends Branch {
+
+    @Override
+    public boolean isValid() { return Timing.isValidTick(); }
+}

--- a/src/main/java/org/dreambot/quests/cooksassistant/FinishedCooksAssistant.java
+++ b/src/main/java/org/dreambot/quests/cooksassistant/FinishedCooksAssistant.java
@@ -1,0 +1,21 @@
+package org.dreambot.quests.cooksassistant;
+
+import org.dreambot.api.methods.settings.PlayerSettings;
+import org.dreambot.api.utilities.Logger;
+import org.dreambot.api.wrappers.interactive.Player;
+import org.dreambot.framework.Leaf;
+import org.dreambot.utilities.QuestVarBits;
+import org.dreambot.utilities.QuestVarPlayer;
+
+public class FinishedCooksAssistant extends Leaf {
+    @Override
+    public boolean isValid() {
+        return PlayerSettings.getConfig(QuestVarPlayer.QUEST_COOKS_ASSISTANT.getId()) >= 2;
+    }
+
+    @Override
+    public int onLoop() {
+        Logger.log("Finished Cook's Assistant! Stopping script...!");
+        return -1;
+    }
+}

--- a/src/main/java/org/dreambot/quests/cooksassistant/GatherItemsLeaf.java
+++ b/src/main/java/org/dreambot/quests/cooksassistant/GatherItemsLeaf.java
@@ -1,0 +1,161 @@
+package org.dreambot.quests.cooksassistant;
+
+import org.dreambot.api.methods.container.impl.Inventory;
+import org.dreambot.api.methods.interactive.GameObjects;
+import org.dreambot.api.methods.interactive.Players;
+import org.dreambot.api.methods.item.GroundItems;
+import org.dreambot.api.methods.map.Area;
+import org.dreambot.api.methods.map.Tile;
+import org.dreambot.api.methods.settings.PlayerSettings;
+import org.dreambot.api.methods.walking.impl.Walking;
+import org.dreambot.api.utilities.Sleep;
+import org.dreambot.api.wrappers.interactive.GameObject;
+import org.dreambot.api.wrappers.items.GroundItem;
+import org.dreambot.framework.Leaf;
+import org.dreambot.utilities.Interaction;
+import org.dreambot.utilities.QuestHelper;
+import org.dreambot.utilities.QuestVarPlayer;
+import org.dreambot.utilities.Timing;
+
+public class GatherItemsLeaf extends Leaf {
+
+    public static boolean HOPPER_LOADED = false; //flips to true upon putting grain in hopper
+
+    private final int GRAIN_TOWER_FLOUR_COUNT_VARBIT = 4920; //Indicates the quantity of flour available to take from bin in west lumbridge grain tower
+    private final Tile POT_LUMBRIDGE_SPAWN = new Tile(3209, 3214, 0);
+    private final Tile EGG_CHICKEN_WEST_SPAWN = new Tile(3185, 3297, 0);
+    private final Tile BUCKET_LUMBRIDGE_SPAWN = new Tile(3216, 9625, 0);
+    private final Area CHICKEN_PEN_WEST_LUMBRIDGE = new Area(
+            new Tile(3185, 3296, 0),
+            new Tile(3185, 3297, 0),
+            new Tile(3183, 3302, 0),
+            new Tile(3173, 3302, 0),
+            new Tile(3175, 3292, 0),
+            new Tile(3181, 3289, 0));
+    private final Area WHEAT_FIELD_AREA = new Area(
+            new Tile(3161, 3293, 0),
+            new Tile(3155, 3297, 0),
+            new Tile(3154, 3305, 0),
+            new Tile(3158, 3304, 0),
+            new Tile(3162, 3299, 0));
+    private final Area GRAIN_TOWER_LVL1_AREA = new Area(
+            new Tile(3168, 3303, 0),
+            new Tile(3166, 3303, 0),
+            new Tile(3163, 3306, 0),
+            new Tile(3166, 3310, 0),
+            new Tile(3167, 3310, 0),
+            new Tile(3170, 3307, 0),
+            new Tile(3170, 3306, 0));
+    private final Area GRAIN_TOWER_LVL3_AREA = new Area(3164, 3309, 3169, 3304, 2);
+    private final Area DAIRY_COW_WEST_LUMBRIDGE_AREA = new Area(3171, 3322, 3177, 3316, 0);
+
+    @Override
+    public boolean isValid() {
+        return (PlayerSettings.getConfig(QuestVarPlayer.QUEST_COOKS_ASSISTANT.getId()) == 0 ||
+                PlayerSettings.getConfig(QuestVarPlayer.QUEST_COOKS_ASSISTANT.getId()) == 1) &&
+                (!Inventory.contains("Bucket of milk") ||
+                        !Inventory.contains("Egg") ||
+                        !Inventory.contains("Pot of flour"));
+    }
+
+
+    @Override
+    public int onLoop() {
+        //get the items
+        if(!Inventory.contains("Pot of flour")) {
+            if(!Inventory.contains("Pot")) {
+                //get bucket and pot together if not have either, because they are so close together, to save a trip
+                if(!Inventory.contains("Bucket")) {
+                    return QuestHelper.pickupGroundSpawn(BUCKET_LUMBRIDGE_SPAWN,"Bucket");
+                }
+                return QuestHelper.pickupGroundSpawn(POT_LUMBRIDGE_SPAWN,"Pot");
+            }
+
+            if(!Inventory.contains("Grain")) {
+                if(!WHEAT_FIELD_AREA.contains(Players.getLocal()))
+                {
+                    if(Walking.shouldWalk(6)) {
+                        Walking.walk(WHEAT_FIELD_AREA.getRandomTile());
+                    }
+                    return Timing.loopReturn();
+                }
+
+                GameObject grain = GameObjects.closest(g -> g.getName().equals("Wheat") && g.hasAction("Pick"));
+                if(grain != null && Interaction.delayEntityInteract(grain,"Pick")) {
+                    Sleep.sleepUntil(() -> Inventory.contains("Grain"), 3000);
+                }
+
+                return Timing.loopReturn();
+            }
+
+            if(PlayerSettings.getBitValue(GRAIN_TOWER_FLOUR_COUNT_VARBIT) > 0) {
+                if(!GRAIN_TOWER_LVL1_AREA.contains(Players.getLocal())) {
+                    if(Walking.shouldWalk(6)) {
+                        Walking.walk(GRAIN_TOWER_LVL1_AREA.getRandomTile());
+                    }
+                    return Timing.loopReturn();
+                }
+
+                GameObject bin = GameObjects.closest(g -> g.hasAction("Empty") && g.getName().equals("Flour bin"));
+                if(bin != null && Interaction.delayEntityInteract(bin, "Empty")) {
+                    Sleep.sleepUntil(() -> Inventory.contains("Pot of flour"), 3000);
+                }
+
+                return Timing.loopReturn();
+            }
+
+            if(!GRAIN_TOWER_LVL3_AREA.contains(Players.getLocal())) {
+                if(Walking.shouldWalk(6)) {
+                    Walking.walk(GRAIN_TOWER_LVL3_AREA.getRandomTile());
+                }
+                return Timing.loopReturn();
+            }
+
+            if(!HOPPER_LOADED) {
+                GameObject hopper = GameObjects.closest(g -> g.hasAction("Fill") && g.getName().equals("Hopper"));
+                if(hopper != null && Interaction.delayEntityInteract(hopper, "Fill")) {
+                    int count = Inventory.count("Grain");
+                    Sleep.sleepUntil(() -> Inventory.count("Grain") < count, () -> Players.getLocal().isMoving(), 3000, 100);
+                    HOPPER_LOADED = true;
+                }
+                return Timing.loopReturn();
+            }
+
+            GameObject lever = GameObjects.closest(g -> g.hasAction("Operate") && g.getName().equals("Hopper controls"));
+            if(lever != null && Interaction.delayEntityInteract(lever , "Operate")) {
+                Sleep.sleepUntil(() -> PlayerSettings.getBitValue(GRAIN_TOWER_FLOUR_COUNT_VARBIT) > 0, () -> Players.getLocal().isMoving(), 3000, 100);
+            }
+
+            return Timing.loopReturn();
+        }
+
+        if(!Inventory.contains("Bucket of milk")) {
+            //Assume that we have started with a pot of flour and no bucket, need to get bucket still
+            if(!Inventory.contains("Bucket")) {
+                return QuestHelper.pickupGroundSpawn(BUCKET_LUMBRIDGE_SPAWN,"Bucket");
+            }
+
+            if(!DAIRY_COW_WEST_LUMBRIDGE_AREA.contains(Players.getLocal())) {
+                if(Walking.shouldWalk(6)) {
+                    Walking.walk(DAIRY_COW_WEST_LUMBRIDGE_AREA.getRandomTile());
+                }
+                return Timing.loopReturn();
+            }
+
+            GameObject dairyCow = GameObjects.closest(g -> g.getName().equals("Dairy cow") && g.hasAction("Milk"));
+            if(dairyCow != null && Interaction.delayEntityInteract(dairyCow, "Milk")) {
+                Sleep.sleepUntil(() -> Inventory.contains("Bucket of milk"), () -> Players.getLocal().isMoving(), 3000, 100);
+            }
+
+            return Timing.loopReturn();
+        }
+
+        if(!Inventory.contains("Egg")) {
+            return QuestHelper.pickupGroundSpawn(EGG_CHICKEN_WEST_SPAWN,"Egg");
+        }
+
+        return Timing.loopReturn();
+
+    }
+
+}

--- a/src/main/java/org/dreambot/quests/cooksassistant/TalkToCookLeaf.java
+++ b/src/main/java/org/dreambot/quests/cooksassistant/TalkToCookLeaf.java
@@ -1,0 +1,24 @@
+package org.dreambot.quests.cooksassistant;
+
+import org.dreambot.api.methods.map.Area;
+import org.dreambot.api.methods.settings.PlayerSettings;
+import org.dreambot.framework.Leaf;
+import org.dreambot.utilities.QuestHelper;
+import org.dreambot.utilities.QuestVarPlayer;
+
+public class TalkToCookLeaf extends Leaf {
+    private final Area COOK_AREA = new Area(3205, 3217, 3212, 3212, 0);
+    private final String COOK_NAME = "Cook";
+    private final String[] DIALOGUE_OPTIONS = {"I'll get right on it."};
+    @Override
+    public boolean isValid() {
+        return PlayerSettings.getConfig(QuestVarPlayer.QUEST_COOKS_ASSISTANT.getId()) == 0 ||
+                PlayerSettings.getConfig(QuestVarPlayer.QUEST_COOKS_ASSISTANT.getId()) == 1;
+    }
+
+
+    @Override
+    public int onLoop() {
+        return QuestHelper.goAndTalkToNpc(COOK_AREA,COOK_NAME, DIALOGUE_OPTIONS);
+    }
+}

--- a/src/main/java/org/dreambot/quests/impcatcher/GiveBeadsLeaf.java
+++ b/src/main/java/org/dreambot/quests/impcatcher/GiveBeadsLeaf.java
@@ -16,14 +16,13 @@ public class GiveBeadsLeaf extends Leaf {
     @Override
     public boolean isValid() {
         return PlayerSettings.getConfig(QuestVarPlayer.QUEST_IMP_CATCHER.getId()) == 0 &&
-                Inventory.contains("Black bead", "Red bead", "White bead", "Yellow bead") ||
+                Inventory.containsAll("Black bead", "Red bead", "White bead", "Yellow bead") ||
                 PlayerSettings.getConfig(QuestVarPlayer.QUEST_IMP_CATCHER.getId()) == 1 &&
-                        Inventory.contains("Black bead", "Red bead", "White bead", "Yellow bead");
+                        Inventory.containsAll("Black bead", "Red bead", "White bead", "Yellow bead");
     }
 
     @Override
     public int onLoop() {
-        QuestHelper.goAndTalkToNpc(MIZGOG_AREA, "Wizard Mizgog", DIALOGUE_OPTIONS);
-        return Timing.loopReturn();
+        return QuestHelper.goAndTalkToNpc(MIZGOG_AREA, "Wizard Mizgog", DIALOGUE_OPTIONS);
     }
 }

--- a/src/main/java/org/dreambot/quests/impcatcher/RetrieveBeadsLeaf.java
+++ b/src/main/java/org/dreambot/quests/impcatcher/RetrieveBeadsLeaf.java
@@ -34,18 +34,19 @@ public class RetrieveBeadsLeaf extends Leaf {
             return Timing.loopReturn();
         }
 
+        GroundItem beads = GroundItems.closest(item -> item.getName().endsWith("beads"));
+        if (beads != null) {
+            if(beads.interact("Take")) {
+                Sleep.sleepUntil(() -> !beads.exists(), () -> Players.getLocal().isMoving(), 3000, 100);
+            }
+            return Timing.loopReturn();
+        }
+
         NPC imp = NPCs.closest("Imp");
         if (imp != null && !Players.getLocal().isInCombat()) {
             if (imp.interact("Attack")) {
                 Sleep.sleepUntil(() -> Players.getLocal().isInCombat(), 3000);
             }
-
-            GroundItem beads = GroundItems.closest(item -> item.getName().endsWith("beads"));
-            if (beads != null) {
-                beads.interact("Take");
-                // Need a sleep check for here.
-            }
-
             return Timing.loopReturn();
         }
 

--- a/src/main/java/org/dreambot/quests/romeoandjuliet/TalkToRomeoLeaf.java
+++ b/src/main/java/org/dreambot/quests/romeoandjuliet/TalkToRomeoLeaf.java
@@ -30,13 +30,11 @@ public class TalkToRomeoLeaf extends Leaf {
     @Override
     public int onLoop() {
         if (PlayerSettings.getBitValue(12139) == 0) {
-            QuestHelper.goAndTalkToNpc(ROMEO_AREA, "Romeo", DIALOGUE_OPTIONS);
-            return Timing.loopReturn();
-        } else {
-            if (Dialogues.inDialogue()) {
-                if (Dialogues.canContinue()) {
-                    Dialogues.continueDialogue();
-                }
+            return QuestHelper.goAndTalkToNpc(ROMEO_AREA, "Romeo", DIALOGUE_OPTIONS);
+        }
+        if (Dialogues.inDialogue()) {
+            if (Dialogues.canContinue()) {
+                Dialogues.continueDialogue();
             }
         }
         return Timing.loopReturn();

--- a/src/main/java/org/dreambot/utilities/Interaction.java
+++ b/src/main/java/org/dreambot/utilities/Interaction.java
@@ -6,7 +6,11 @@ import org.dreambot.api.wrappers.interactive.Entity;
 
 public class Interaction {
     public static boolean delayEntityInteract(Entity entity, String action, long sleepDelay) {
-        Sleep.sleep((int)sleepDelay);
-        return true;
+        Sleep.sleep(sleepDelay);
+        return entity.interact(action);
+    }
+    public static boolean delayEntityInteract(Entity entity, String action) {
+        Sleep.sleep(Timing.getSleepDelay());
+        return entity.interact(action);
     }
 }

--- a/src/main/java/org/dreambot/utilities/QuestHelper.java
+++ b/src/main/java/org/dreambot/utilities/QuestHelper.java
@@ -1,12 +1,24 @@
 package org.dreambot.utilities;
 
+import org.dreambot.api.methods.container.impl.Inventory;
 import org.dreambot.api.methods.dialogues.Dialogues;
+import org.dreambot.api.methods.filter.Filter;
+import org.dreambot.api.methods.interactive.GameObjects;
 import org.dreambot.api.methods.interactive.NPCs;
 import org.dreambot.api.methods.interactive.Players;
+import org.dreambot.api.methods.item.GroundItems;
 import org.dreambot.api.methods.map.Area;
+import org.dreambot.api.methods.map.Map;
+import org.dreambot.api.methods.map.Tile;
 import org.dreambot.api.methods.walking.impl.Walking;
+import org.dreambot.api.utilities.Logger;
 import org.dreambot.api.utilities.Sleep;
+import org.dreambot.api.utilities.impl.Condition;
+import org.dreambot.api.wrappers.interactive.GameObject;
 import org.dreambot.api.wrappers.interactive.NPC;
+import org.dreambot.api.wrappers.items.GroundItem;
+
+import java.util.Comparator;
 
 public class QuestHelper {
 
@@ -21,7 +33,7 @@ public class QuestHelper {
         if (!Dialogues.inDialogue()) {
             NPC npc = NPCs.closest(n -> n.getName().equals(name));
             if (npc != null && npc.interact("Talk-to")) {
-                Sleep.sleepUntil(() -> Dialogues.inDialogue(), 3000);
+                Sleep.sleepUntil(() -> Dialogues.inDialogue(), () -> Players.getLocal().isMoving(), 3000, 100);
             }
             return Timing.loopReturn();
         }
@@ -42,4 +54,47 @@ public class QuestHelper {
 
         return Timing.loopReturn();
     }
+
+
+
+
+    public static int pickupGroundSpawn(Tile tile, String name) {
+        if(tile.distance() >= 15) {
+            if(Walking.shouldWalk(6)) {
+                Walking.walk(tile);
+            }
+            return Timing.loopReturn();
+        }
+
+        Tile interactableTile = null;
+        GroundItem groundItem = GroundItems.closest(x -> x != null && x.exists() && x.getTile().equals(tile) && x.getName().equals(name));
+        if(groundItem != null) {
+            if(groundItem.canReach()) interactableTile = groundItem.getTile();
+            else {
+                GameObject gob = GameObjects.getTopObjectOnTile(groundItem.getTile());
+                if(gob != null && gob.canReach()){
+                    Tile target = gob.getInteractableFrom().stream()
+                            .filter(x -> x != null && x.distance(groundItem.getTile()) <= 1)
+                            .min(Comparator.comparingDouble(Tile::distance))
+                            .orElse(null);
+                    if(target != null) {
+                        interactableTile = target;
+                    }
+                }
+            }
+            if(interactableTile != null && interactableTile.canReach() && Interaction.delayEntityInteract(groundItem, "Take")) {
+                int count = Inventory.count(name);
+                Sleep.sleepUntil(() -> Inventory.count(name) > count, () -> Players.getLocal().isMoving(), 3000, 100);
+                return Timing.loopReturn();
+            }
+        }
+
+        if(Walking.shouldWalk(6)) {
+            Walking.walk(tile);
+        }
+
+        return Timing.loopReturn();
+    }
+
+
 }

--- a/src/main/java/org/dreambot/utilities/Timing.java
+++ b/src/main/java/org/dreambot/utilities/Timing.java
@@ -1,23 +1,24 @@
 package org.dreambot.utilities;
 
 import org.dreambot.api.methods.Calculations;
+import org.dreambot.api.utilities.Sleep;
 
 public class Timing {
     // Variables to hold our various timings
     public static int tickTimeout = 3;
     public static long sleepLength = 100;
     // Sleep Settings
-    public static int sleepMin = 60;
-    public static int sleepMax = 350;
-    public static int sleepDeviation = 10;
-    public static int sleepTarget = 100;
-    public static boolean sleepWeightedDistribution = false;
+    public static int sleepMin = 75;
+    public static int sleepMax = 450;
+    public static int sleepDeviation = 20;
+    public static int sleepTarget = 140;
+    public static boolean sleepWeightedDistribution = true;
     // Tick Settings
     public static int tickDelayMin = 1;
     public static int tickDelayMax = 5;
     public static int tickDelayDeviation = 1;
-    public static int tickDelayTarget = 3;
-    public static boolean tickDelayWeightedDistribution = false;
+    public static int tickDelayTarget = 2;
+    public static boolean tickDelayWeightedDistribution = true;
 
     public static boolean isValidTick() {
         return tickTimeout == 0;
@@ -25,13 +26,13 @@ public class Timing {
 
     public static int loopReturn() {
         tickTimeout += getTickDelay();
-        return 600;
+        Sleep.sleepTick();
+        return 60;
     }
 
     // Get a randomized sleep delay
     public static long getSleepDelay() {
-        sleepLength = getRandomDelay(sleepWeightedDistribution, sleepMin, sleepMax, sleepDeviation, sleepTarget);
-        return sleepLength;
+        return getRandomDelay(sleepWeightedDistribution, sleepMin, sleepMax, sleepDeviation, sleepTarget);
     }
 
     // Get a randomized timeout delay


### PR DESCRIPTION
Added method in QuestHelper pickupGroundSpawn(Tile, String name) mainly for walking from anywhere and picking up a GroundItem at a tile, handling closed doors & blocked pickup tile. 

Implemented tick timeout function and delayed interactions in Cooks Assistant, if it looks good then we can change all interactions to delayed interactions. 

goAndTalkToNpc returns Timing.loopReturn as int so changed that in most quests to avoid redundancy.

In Imp Catcher changed isValid of GiveBeadsLeaf from Inventory.contains(beads...) to Inventory.containsAll(beads...) because I assume we need all beads before talking to Mizgog and contains(...) only checks for at least one of provided list to return true. 

Added sleepUntil condition where you commented in Imp Catcher.

In Imp Catcher, moved GroundItems beads check above NPC check in case no imps but there are beads on the ground.